### PR TITLE
Ignore offline message loading

### DIFF
--- a/src/Defaults/index.ts
+++ b/src/Defaults/index.ts
@@ -66,6 +66,7 @@ export const DEFAULT_CONNECTION_CONFIG: SocketConfig = {
 	customUploadHosts: [],
 	retryRequestDelayMs: 250,
 	maxMsgRetryCount: 5,
+	ignoreMsgLoading: false,
 	fireInitQueries: true,
 	auth: undefined as unknown as AuthenticationState,
 	markOnlineOnConnect: true,

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -52,6 +52,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		logger,
 		retryRequestDelayMs,
 		maxMsgRetryCount,
+		ignoreMsgLoading,
 		getMessage,
 		shouldIgnoreJid
 	} = config
@@ -867,6 +868,11 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 	}
 
 	const handleMessage = async(node: BinaryNode) => {
+		if(ignoreMsgLoading && node.attrs.offline) {
+			logger.debug({ key: node.attrs.key }, 'ignored offline message')
+			await sendMessageAck(node)
+			return
+		}
 		if(shouldIgnoreJid(node.attrs.from) && node.attrs.from !== '@s.whatsapp.net') {
 			logger.debug({ key: node.attrs.key }, 'ignored message')
 			await sendMessageAck(node)

--- a/src/Types/Socket.ts
+++ b/src/Types/Socket.ts
@@ -82,6 +82,8 @@ export type SocketConfig = {
     linkPreviewImageThumbnailWidth: number
     /** Should Baileys ask the phone for full history, will be received async */
     syncFullHistory: boolean
+    /** Ignore Message when offline, default is false */
+    ignoreMsgLoading: boolean
     /** Should baileys fire init queries automatically, default true */
     fireInitQueries: boolean
     /**


### PR DESCRIPTION
# Ignore Message Loading when Offline 

### you need to set-up this in your Socket connection system

```ts
ignoreMsgLoading: true
```

## Features or Use case
* Avoid Loading all messages that got when bot or your application was offline
*  Beneficial for users who dont want to make application heavy or dont want to waste time in loading old messages

© Yugesh Singh Shizo (@shizothetechie )